### PR TITLE
Added scroll behaviour to to `TableSideBar`

### DIFF
--- a/frontend/src/Pages/Tables/TablesSidebar.vue
+++ b/frontend/src/Pages/Tables/TablesSidebar.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="w-full max-w-[13em] bg-main-800 divide-y divide-slate-600">
+	<div class="w-full max-w-[13em] bg-main-800 divide-y divide-slate-600 overflow-y-scroll">
 		<div class="flex flex-col  justify-center">
 			<p class="py-3 px-6 text-lg">Tables</p>
 		</div>


### PR DESCRIPTION
The side bar's default overflow behaviour is to hide the overflowing content, which is a problem when you have a lot of tables in your database. This PR fixes that and allows for it to scroll on overflow.